### PR TITLE
Increasing sparse size for data.lmdb

### DIFF
--- a/config/config-example.toml
+++ b/config/config-example.toml
@@ -314,7 +314,7 @@ verify_accounts = true
 # If unset, defaults to 805,306,368,000 == 750 GiB.
 #
 # The size should be a multiple of the OS page size.
-max_global_state_size = 1_099_511_627_776
+max_global_state_size = 1_904_817_995_776
 
 # Optional depth limit to use for global state queries.
 #


### PR DESCRIPTION
Increasing size limit for data.lmdb as unable to sync to tip in 1.4.5 without this increased.