### PR TITLE
Use commit hash for the ncipollo/release-action for sec reasons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         tar -cvzf config.tar.gz -C config .
 
     - name: Creating release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37
       with:
         artifacts: "config.tar.gz"
         allowUpdates: true


### PR DESCRIPTION
Implementing security best practice.
More info: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions